### PR TITLE
Define the zettle default location

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ entirely sure how to manage dependencies but if you do know how here they are:
 # Setup
 
 `zettel-mode` stores your notes in a directory defined by the `ZETTELPATH`
-environment variable that you should set somewhere to e.g. `~/.zettel`
+environment variable that you should set somewhere to e.g. `~/.zettelkasten`
 
 ## Features
 

--- a/zettel-mode.el
+++ b/zettel-mode.el
@@ -23,8 +23,8 @@
 (require 'counsel)
 (require 'json)
 
-(defvar neuron-zettelkasten (expand-file-name "~/.zettle")
-  "The zettle location.")
+(defvar neuron-zettelkasten (expand-file-name "~/.zettelkasten")
+  "The zettels folder location.")
 
 ;; (defun neuron-zettelkasten-list ()
 ;;   "Return the list of zettelkastens."

--- a/zettel-mode.el
+++ b/zettel-mode.el
@@ -23,7 +23,8 @@
 (require 'counsel)
 (require 'json)
 
-(defvar neuron-zettelkasten nil)
+(defvar neuron-zettelkasten (expand-file-name "~/.zettle")
+  "The zettle location.")
 
 ;; (defun neuron-zettelkasten-list ()
 ;;   "Return the list of zettelkastens."
@@ -32,6 +33,7 @@
 (defun neuron--command (cmd)
   "Run a neuron command in the current zettekasten.
 CMD should be a string representing the command"
+  (make-directory neuron-zettelkasten :parents)
   (shell-command-to-string (concat "neuron " neuron-zettelkasten " " cmd)))
 
 (defun neuron--json-extract-info (match)


### PR DESCRIPTION
This change prevents failure when the neuron-zettelkasten variable
is not set.