### PR TITLE
Add neuron-rib-generate 

### DIFF
--- a/zettel-mode.el
+++ b/zettel-mode.el
@@ -65,6 +65,10 @@ returned as a string."
   "Run an asynchronous neuron process spawned by the rib command with arguments ARGS."
   (start-process-shell-command "rib" "*rib*" (apply #'neuron--make-command "rib" args)))
 
+(defun neuron--run-rib-compile (&rest args)
+  "Run an synchronous neuron command spawned by the rib command with arguments ARGS."
+  (compile (apply #'neuron--make-command "rib" args)))
+
 (defun neuron-select-zettelkasten ()
   "Select the active zettelkasten."
   (interactive)
@@ -195,6 +199,13 @@ Execute BEFORE just before popping the buffer and AFTER just after enabling `zet
   (interactive)
   (if (neuron--run-rib-process "-wS")
       (message "Started web application on localhost:8080")
+    (message "Rib command failed")))
+
+(defun neuron-rib-generate ()
+  "Do an one-off generation of the web interface of the zettelkasten."
+  (interactive)
+  (if (neuron--run-rib-compile)
+      (message "Generated HTML files")
     (message "Rib command failed")))
 
 (defun neuron-rib-open-page (page)

--- a/zettel-mode.el
+++ b/zettel-mode.el
@@ -165,6 +165,7 @@ Execute BEFORE just before popping the buffer and AFTER just after enabling `zet
 
 (defun neuron-open-current-zettel ()
   "Open the current zettel's HTML file in the browser."
+  (interactive)
   (neuron--open-zettel-from-id (neuron--get-current-zettel-id)))
 
 (defun neuron-follow-thing-at-point ()


### PR DESCRIPTION
With multiple zettelkastens, I rarely use `-w` (much less `-wS`). So doing an one-off generation right after editing a few zettels is a typical use case for me.

This PR also exposes `neuron-open-current-zettel` to the user 