### PR TITLE
Use non-empty title in "neuron new"

### DIFF
--- a/zettel-mode.el
+++ b/zettel-mode.el
@@ -77,7 +77,7 @@ returned as a string."
 (defun neuron-new-zettel ()
   "Create a new zettel in the current zettelkasten."
   (interactive)
-  (when-let* ((path (neuron--run-command "new" ""))
+  (when-let* ((path (neuron--run-command "new" "Untitled"))
               (buffer (find-file-noselect path)))
     (and
      (pop-to-buffer-same-window buffer)
@@ -124,7 +124,7 @@ Return the ID of the selected zettel."
 (defun neuron-insert-new-zettel ()
   "Create a new zettel."
   (interactive)
-  (when-let* ((path   (neuron--run-command "new" ""))
+  (when-let* ((path   (neuron--run-command "new" "Untitled"))
               (id     (f-base (f-no-ext path)))
               (buffer (find-file-noselect path)))
     (and


### PR DESCRIPTION
Otherwise, `rib -w` will display errors, and won't render the new file.

The title argument will likely become optional as part of https://github.com/srid/neuron/issues/123