### PR TITLE
Repair `neuron-title-overlay-face', resolving compiler error

### DIFF
--- a/neuron-mode.el
+++ b/neuron-mode.el
@@ -111,7 +111,7 @@ of the zettel."
 (defface neuron-title-overlay-face
   '((((class color) (min-colors 88) (background dark)) :foreground "MistyRose2")
     (((class color) (min-colors 88) (background light)) :foreground "LightSlateGrey")
-    ((class color) :foreground "grey")
+    (((class color) :foreground "grey"))
     (t :inherit italic))
   "Face for title overlays displayed next to short links."
   :group 'neuron-face)


### PR DESCRIPTION
`neuron-title-overlay-face` was missing a level of nesting which
caused the following compiler error:

```
Debugger entered--Lisp error: (wrong-type-argument listp class)
  face-spec-set-match-display((class color) #<frame F1 0xa967b0>)
...
```