### PR TITLE
Replace an undefined function with a cognate

### DIFF
--- a/neuron-mode.el
+++ b/neuron-mode.el
@@ -592,7 +592,7 @@ NO-PROMPT is non-nil do not prompt when creating a new zettel."
                 (query (neuron--parse-query-from-url-or-id link))
                 (conn (alist-get 'conn query))
                 (toggled (if (eq conn 'ordinary) 'folgezettel 'ordinary))
-                (new-query (progn (map-put! query 'conn toggled) query)))
+                (new-query (progn (map-put query 'conn toggled) query)))
           (save-excursion
             (goto-char start)
             (delete-region start end)

--- a/neuron-mode.el
+++ b/neuron-mode.el
@@ -592,7 +592,7 @@ NO-PROMPT is non-nil do not prompt when creating a new zettel."
                 (query (neuron--parse-query-from-url-or-id link))
                 (conn (alist-get 'conn query))
                 (toggled (if (eq conn 'ordinary) 'folgezettel 'ordinary))
-                (new-query (progn (map-put query 'conn toggled) query)))
+                (new-query (progn (setf (map-elt query 'conn nil) toggled) query)))
           (save-excursion
             (goto-char start)
             (delete-region start end)


### PR DESCRIPTION
The `map-put!` function is not defined in Emacs 26.3 with recent
copies of `f`, `s`, `dash`, and `markdown-mode` installed. However,
`map-put` is, and seems to maintain the intended effects. Namely, with
this modification calling the function `neuron-toggle-connection-type`
on a link toggles whether `?cf` is included at the end of the link.